### PR TITLE
feat(classes): expose admin endpoint to list classes by user id

### DIFF
--- a/src/controllers/class.controller.js
+++ b/src/controllers/class.controller.js
@@ -76,3 +76,18 @@ export const deleteClass = async (req, res) => {
     return res.status(error.status || 500).json({ success: false, message: error.message || "L?i server" });
   }
 };
+
+export const getClassesByUser = async (req, res) => {
+  try{
+    const{ id } = req.params;
+    const classes = await classService.getByUserId(id);
+     
+    res.status(200).json({
+      success: true,
+      message: "Lấy danh sách lớp theo giáo viên thành công",
+      data: classes 
+    });
+  } catch(error){
+    return res.status(error.status || 500).json({ success: false , message: error.message || "Lỗi server"});
+  }
+};

--- a/src/controllers/class.controller.js
+++ b/src/controllers/class.controller.js
@@ -77,17 +77,21 @@ export const deleteClass = async (req, res) => {
   }
 };
 
-export const getClassesByUser = async (req, res) => {
+export const getMyClasses  = async (req, res) => {
   try{
-    const{ id } = req.params;
-    const classes = await classService.getByUserId(id);
+    const teacherId = req.payload.userId;
      
-    res.status(200).json({
+    const classes = await classService.getByUserId(teacherId);
+
+    return res.status(200).json({
       success: true,
-      message: "Lấy danh sách lớp theo giáo viên thành công",
-      data: classes 
+      message: "Lấy danh sách lớp của giáo viên thành công",
+      data: classes
     });
-  } catch(error){
-    return res.status(error.status || 500).json({ success: false , message: error.message || "Lỗi server"});
+  } catch (error) {
+    return res.status(error.status || 500).json({
+      success: false,
+      message: error.message || "Lỗi server"
+    });
   }
 };

--- a/src/routers/class.router.js
+++ b/src/routers/class.router.js
@@ -10,12 +10,12 @@ import {
 } from '../validations/class.validation.js';
 
 const classRouter = express.Router();
-
+classRouter.get('/user', authenticate, authorize(ROLE.TEACHER), classController.getMyClasses);
 classRouter.get('/', validate(getClassesQuerySchema, 'query'), classController.getAllClasses);
 classRouter.get('/:id', classController.getClassById);
 classRouter.post('/', authenticate, authorize(ROLE.ADMIN), validate(createClassSchema), classController.createClass);
 classRouter.put('/:id', authenticate, authorize(ROLE.ADMIN), validate(updateClassSchema), classController.updateClass);
 classRouter.delete('/:id', authenticate, authorize(ROLE.ADMIN), classController.deleteClass);
-classRouter.get('/user/:id', authenticate, authorize(ROLE.ADMIN), classController.getClassesByUser);
+
 
 export default classRouter;

--- a/src/routers/class.router.js
+++ b/src/routers/class.router.js
@@ -16,5 +16,6 @@ classRouter.get('/:id', classController.getClassById);
 classRouter.post('/', authenticate, authorize(ROLE.ADMIN), validate(createClassSchema), classController.createClass);
 classRouter.put('/:id', authenticate, authorize(ROLE.ADMIN), validate(updateClassSchema), classController.updateClass);
 classRouter.delete('/:id', authenticate, authorize(ROLE.ADMIN), classController.deleteClass);
+classRouter.get('/user/:id', authenticate, authorize(ROLE.ADMIN), classController.getClassesByUser);
 
 export default classRouter;

--- a/src/services/class.service.js
+++ b/src/services/class.service.js
@@ -162,5 +162,13 @@ export const classService = {
             .sort({ schoolYear: -1, name: 1 });
             
         return classes.map(toClassResponse);
+    },
+    
+    async getByUserId(id){
+        const classes = await Class.find({teachers: id})
+            .populate('level teachers')
+            .sort({ createdAt: -1});
+
+        return classes.map(toClassResponse);
     }
 };

--- a/src/swagger/class.swagger.js
+++ b/src/swagger/class.swagger.js
@@ -304,5 +304,26 @@ export const classSwagger = {
         500: { description: 'Lỗi server' }
       }
     }
+  },
+    '/api/classes/user/{id}': {
+  get: {
+    tags: ['Classes'],
+    summary: 'ADMIN: Lấy danh sách lớp mà một người dùng đang dạy',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        in: 'path',
+        name: 'id',
+        required: true,
+        schema: { type: 'string', example: '68c3c432b180b339805cb5e5' },
+        description: 'ObjectId của user (teacher)'
+      }
+    ],
+    responses: {
+      200: { description: 'OK' },
+      401: { description: 'Không có quyền truy cập' },
+      500: { description: 'Lỗi server' }
+    }
   }
+},
 };

--- a/src/swagger/class.swagger.js
+++ b/src/swagger/class.swagger.js
@@ -305,25 +305,62 @@ export const classSwagger = {
       }
     }
   },
-    '/api/classes/user/{id}': {
-  get: {
-    tags: ['Classes'],
-    summary: 'ADMIN: Lấy danh sách lớp mà một người dùng đang dạy',
-    security: [{ bearerAuth: [] }],
-    parameters: [
-      {
-        in: 'path',
-        name: 'id',
-        required: true,
-        schema: { type: 'string', example: '68c3c432b180b339805cb5e5' },
-        description: 'ObjectId của user (teacher)'
+  '/api/classes/user': {
+    get: {
+      tags: ['Classes'],
+      summary: 'Lấy danh sách lớp của Teacher (id lấy từ token)',
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: {
+          description: 'Lấy danh sách lớp thành công',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  success: { type: 'boolean', example: true },
+                  message: { type: 'string', example: 'Lấy danh sách lớp của giáo viên thành công' },
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string', example: 'Mầm 1' },
+                        schoolYear: { type: 'string', example: '2025-2026' },
+                        level: {
+                          type: 'object',
+                          properties: {
+                            id: { type: 'string' },
+                            name: { type: 'string', example: 'Mầm' }
+                          }
+                        },
+                        teachers: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              fullName: { type: 'string' },
+                              email: { type: 'string' },
+                              role: { type: 'string', example: 'TEACHER' }
+                            }
+                          }
+                        },
+                        createdAt: { type: 'string' },
+                        updatedAt: { type: 'string' }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        401: { description: 'Chưa đăng nhập' },
+        403: { description: 'Không có quyền (chỉ TEACHER)' },
+        500: { description: 'Lỗi server' }
       }
-    ],
-    responses: {
-      200: { description: 'OK' },
-      401: { description: 'Không có quyền truy cập' },
-      500: { description: 'Lỗi server' }
     }
-  }
-},
+  },
 };


### PR DESCRIPTION
- service: thêm getByUserId(id), cast ObjectId
- controller: trả 200 cùng mảng (kể cả rỗng)
- router: thêm /api/classes/user/:id với authenticate + authorize(ADMIN)
- swagger: bổ sung path /api/classes/user/{id}

Test plan:
 cURL:
  curl -H "Authorization: Bearer <ADMIN_TOKEN>" \
       http://localhost:8080/api/classes/user/68c3c432b180b339805cb5e5